### PR TITLE
Update pc link

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -1,5 +1,5 @@
 Belt: https://www.amazon.com/gp/product/B011R8SN52
-PC: https://www.intel.com/content/www/us/en/products/boards-kits/nuc/kits/nuc8i7hvk.html
+PC: https://www.intel.com/content/dam/support/us/en/documents/mini-pcs/nuc-kits/NUC8i7HVK_TechProdSpec.pdf
 Battery: https://www.amazon.com/Makita-BL1830B-2-Lithium-Ion-3-0Ah-Battery/dp/B01M2VEHDL/ref=dp_ob_title_hi
 Battery contacts: https://www.ebay.com/itm/263629602762?ViewItem=&item=263629602762
 Cable: https://www.ebay.com/itm/Power-Plug-Connector-Cable-Cord-For-HP-Dell-Samsung-ASUS-EEE-PC-Laptop-Adapter/371858630342?ssPageName=STRK%3AMEBIDX%3AIT&var=640834242520&_trksid=p2057872.m2749.l2649


### PR DESCRIPTION
Hi @eclecticc 

on my quest to hunt down drivers for the Radeon RX Vega M GH in the Intel NUC8I7HVK I came across this project. 

I noticed your link to the computer was dead and replaced it with a link to it's technical specification from Intel.

Btw: ASUS took over the NUC division and all support for it from Intel: Drivers, Firmware, Docs and Fixes for this device are now available at https://www.asus.com/supportonly/nuc8i7hvk/helpdesk_download/

**But why?** Some guy somewhere once told me that if... _only one person happens upon this years down the road and it saves them a few hours or gives them the reference point they needed, it was worth sharing_ ...and that really stuck! :wink: 

Have a nice day!